### PR TITLE
Add bun tests for business logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "bun test"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.812.0",

--- a/server/__tests__/business-logic.test.ts
+++ b/server/__tests__/business-logic.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "bun:test";
+import { calculateTier } from "../lib/business-logic";
+
+test("fewer than 3 chores maps tickets to tiers", () => {
+  const chores = [
+    { tickets: 2, is_active: true },
+    { tickets: 7, is_active: true }
+  ] as any;
+
+  expect(calculateTier(3, chores)).toBe("common");
+  expect(calculateTier(7, chores)).toBe("rare");
+  expect(calculateTier(11, chores)).toBe("epic");
+});
+
+test("larger set categorizes relative to median", () => {
+  const chores = [
+    { tickets: 2, is_active: true },
+    { tickets: 4, is_active: true },
+    { tickets: 6, is_active: true },
+    { tickets: 8, is_active: true },
+    { tickets: 10, is_active: true },
+  ] as any;
+
+  expect(calculateTier(2, chores)).toBe("common");
+  expect(calculateTier(6, chores)).toBe("rare");
+  expect(calculateTier(10, chores)).toBe("epic");
+});

--- a/server/lib/business-logic.ts
+++ b/server/lib/business-logic.ts
@@ -1,4 +1,4 @@
-import { Chore } from "@shared/schema";
+import type { Chore } from "@shared/schema";
 
 /**
  * Calculate the tier of a chore based on tickets compared to other chores


### PR DESCRIPTION
## Summary
- add `bun test` script
- update business logic to use type-only import
- test `calculateTier` for small and large chore sets

## Testing
- `npm test`