### PR TITLE
Fix Dockerfile user creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,17 @@ RUN npm install dotenv
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/nodejs/.cache/ms-playwright
 RUN npx playwright install chromium --with-deps
 
+# Create the nodejs user before switching to it
+RUN groupadd -g 1001 nodejs \
+    && useradd -u 1001 -g nodejs -m nodejs
+
 USER nodejs
 
 # Copy the rest of the application
 COPY . .
+
+# Ensure nodejs user owns the source files so build tools can write cache files
+RUN chown -R nodejs:nodejs /app
 
 # Build the application
 RUN npm run build


### PR DESCRIPTION
## Summary
- ensure `nodejs` user and group are created before switching
- chown source files so build tools can write during build

## Testing
- `npm test`
