### PR TITLE
Fix server crash on errors and expose port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ WORKDIR /app
 COPY --from=builder /app .
 
 ENV NODE_ENV=production
+ENV PORT=5000
 EXPOSE 5000
 
 # drop privileges for runtime

--- a/server/index.ts
+++ b/server/index.ts
@@ -60,7 +60,8 @@ app.use((req, res, next) => {
     const message = err.message || "Internal Server Error";
 
     res.status(status).json({ message });
-    throw err;
+    // Log the error instead of rethrowing to avoid crashing the process
+    console.error(err);
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- log errors instead of crashing the Express app
- set `PORT` env var in Dockerfile so Render can control the port

## Testing
- `npm test`
- `docker build` *(fails: `docker: command not found`)*