### PR TITLE
Remove legacy image upload route

### DIFF
--- a/client/src/components/new-chore-dialog.tsx
+++ b/client/src/components/new-chore-dialog.tsx
@@ -109,8 +109,11 @@ export function NewChoreDialog({ children, chore, onChoreCreated }: NewChoreDial
       const authStore = JSON.parse(localStorage.getItem('ticket-tracker-auth') || '{}');
       const token = authStore?.state?.token;
       
+      // Determine current user ID for the profile image endpoint
+      const userId = authStore?.state?.user?.id ?? '';
+
       // Manual fetch with token for FormData upload
-      const response = await fetch('/api/upload/image', {
+      const response = await fetch(`/api/profile-image/${userId}`, {
         method: 'POST',
         body: formData,
         headers: {
@@ -124,8 +127,8 @@ export function NewChoreDialog({ children, chore, onChoreCreated }: NewChoreDial
       }
       
       const data = await response.json();
-      
-      form.setValue('image_url', data.imageUrl);
+
+      form.setValue('image_url', data.profile_image_url || data.imageUrl);
       
       toast({
         title: "Image uploaded",

--- a/client/src/components/profile-image-modal.tsx
+++ b/client/src/components/profile-image-modal.tsx
@@ -104,8 +104,8 @@ export default function ProfileImageModal({ isOpen, onClose, user }: ProfileImag
       const formData = new FormData();
       formData.append('image', selectedFile); // Must use 'image' to match what the server expects
       
-      // Use the generic upload endpoint used for chore images instead
-      const uploadUrl = `/api/upload/image`;
+      // Use the profile image upload endpoint
+      const uploadUrl = `/api/profile-image/${user.id}`;
       
       // Log details for debugging
       console.log(`[UPLOAD] File: ${selectedFile.name}, Size: ${selectedFile.size} bytes`);


### PR DESCRIPTION
## Summary
- delete `/api/upload/image` endpoint
- switch profile and chore image forms to new `/api/profile-image/:userId`

## Testing
- `bun test`
