### PR TITLE
Fix daily bonus spin tracking

### DIFF
--- a/migrations/0001_daily_bonus_trigger.sql
+++ b/migrations/0001_daily_bonus_trigger.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION ensure_daily_bonus_is_spun_consistency()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.is_spun := NEW.spin_result_tickets IS NOT NULL;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+CREATE TRIGGER daily_bonus_is_spun_consistency
+BEFORE INSERT OR UPDATE ON "daily_bonus"
+FOR EACH ROW EXECUTE FUNCTION ensure_daily_bonus_is_spun_consistency();

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1747239117437,
       "tag": "0000_exotic_venus",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1747684467627,
+      "tag": "0001_daily_bonus_trigger",
+      "breakpoints": false
     }
   ]
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -246,35 +246,7 @@ export class DatabaseStorage implements IStorage {
         is_spun: existingBonus.is_spun,
         trigger_type: existingBonus.trigger_type
       });
-      
-      // BUGFIX: If we found a bonus with is_spun incorrectly set to true, fix it here
-      if (existingBonus.is_spun) {
-        console.log(`[BONUS_ASSIGN] IMPORTANT: Existing bonus for user ${childId} is marked as already spun.`);
-        console.log(`[BONUS_ASSIGN] DEBUG FIX: Resetting is_spun to false to allow wheel to trigger.`);
-        
-        try {
-          // Fix the is_spun flag so the wheel can be triggered
-          await db
-            .update(dailyBonus)
-            .set({ is_spun: false })
-            .where(eq(dailyBonus.id, existingBonus.id));
-            
-          console.log(`[BONUS_ASSIGN] Successfully reset is_spun flag to false for bonus ${existingBonus.id}`);
-          
-          // Re-fetch the updated bonus
-          const updatedBonus = await this.getDailyBonusById(existingBonus.id);
-          if (updatedBonus) {
-            console.log(`[BONUS_ASSIGN] Updated bonus state:`, {
-              id: updatedBonus.id,
-              is_spun: updatedBonus.is_spun
-            });
-            return updatedBonus;
-          }
-        } catch (err) {
-          console.error(`[BONUS_ASSIGN] Error resetting is_spun flag:`, err);
-        }
-      }
-      
+
       return existingBonus;
     }
     


### PR DESCRIPTION
## Summary
- create DB trigger to keep daily_bonus.is_spun synced with spin_result_tickets
- drop the old recovery block in `assignDailyBonusChore`
- record new migration in journal

## Testing
- `npm test`
- `bun test`
- `docker build` *(fails: command not found)*