### PR TITLE
Add error status propagation

### DIFF
--- a/client/src/components/wishlist-card.tsx
+++ b/client/src/components/wishlist-card.tsx
@@ -69,9 +69,9 @@ export default function WishlistCard({ goal, onSetAsGoal, onDelete, refreshList 
       if (refreshList) {
         refreshList();
       }
-    } catch (error) {
+    } catch (error: any) {
       // If we get a 404, it means the goal was already deleted - which is fine
-      if (error instanceof Error && error.message?.includes('404')) {
+      if (error?.status === 404) {
         toast({
           title: "Goal deleted",
           description: "The goal has been removed from your wishlist",

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -5,7 +5,9 @@ async function throwIfResNotOk(res: Response) {
     // Clone the response before reading the body
     const clonedRes = res.clone();
     const text = (await clonedRes.text()) || res.statusText;
-    throw new Error(`${res.status}: ${text}`);
+    const err: any = new Error(`${res.status}: ${text}`);
+    err.status = res.status;
+    throw err;
   }
 }
 

--- a/client/src/store/goal-store.ts
+++ b/client/src/store/goal-store.ts
@@ -57,8 +57,8 @@ export const useGoalStore = create<GoalState>((set, get) => ({
       const response = await apiRequest('GET', '/api/goals/active');
       const data = await response.json();
       set({ activeGoal: data, isLoading: false });
-    } catch (error) {
-      if (error.message?.includes('404')) {
+    } catch (error: any) {
+      if (error?.status === 404) {
         // No active goal is not an error
         set({ activeGoal: null, isLoading: false });
       } else {


### PR DESCRIPTION
## Summary
- include status code when throwing fetch errors
- check error.status instead of error.message parsing in wishlist and goal store

## Testing
- `npm run check` *(fails: Cannot find type definition file)*
- `bun test`