### PR TITLE
Rename tickets prop to base_tickets in client

### DIFF
--- a/client/src/components/chore-card.tsx
+++ b/client/src/components/chore-card.tsx
@@ -11,7 +11,7 @@ interface ChoreCardProps {
     id: number;
     name: string;
     description: string;
-    tickets: number;
+    base_tickets: number;
     tier: string;
     is_active: boolean;
     image_url?: string;
@@ -123,7 +123,7 @@ export default function ChoreCard({ chore, onComplete, onBonusComplete }: ChoreC
             <div className="ml-3">
               <div className="flex items-center">
                 <p className="text-sm font-medium text-gray-900 dark:text-white">
-                  {chore.tickets} tickets
+                  {chore.base_tickets} tickets
                 </p>
                 {isBonusChore && (
                   <span className="ml-2 text-xs bg-yellow-100 dark:bg-yellow-900/50 text-yellow-800 dark:text-yellow-200 px-2 py-0.5 rounded-md font-semibold">

--- a/client/src/components/daily-bonus-assignments.tsx
+++ b/client/src/components/daily-bonus-assignments.tsx
@@ -13,7 +13,7 @@ import { formatDistanceToNow } from 'date-fns';
 type Chore = {
   id: number;
   name: string;
-  tickets: number;
+  base_tickets: number;
   emoji: string | null;
   is_active: boolean;
   last_bonus_assigned: string | null;
@@ -188,7 +188,7 @@ export function DailyBonusAssignments() {
                         )}
                         <span>{assignment.assigned_chore.name}</span>
                         <span className="text-sm text-muted-foreground ml-auto">
-                          {assignment.assigned_chore.tickets} tickets
+                          {assignment.assigned_chore.base_tickets} tickets
                         </span>
                       </div>
                     </div>
@@ -221,7 +221,7 @@ export function DailyBonusAssignments() {
                             <div className="flex items-center gap-2">
                               {chore.emoji && <span>{chore.emoji}</span>}
                               <span>{chore.name}</span>
-                              <span className="text-muted-foreground">({chore.tickets} tickets)</span>
+                              <span className="text-muted-foreground">({chore.base_tickets} tickets)</span>
                             </div>
                           </SelectItem>
                         ))}

--- a/client/src/components/new-chore-dialog.tsx
+++ b/client/src/components/new-chore-dialog.tsx
@@ -39,7 +39,7 @@ const formSchema = z.object({
     message: "Chore name must be at least 2 characters",
   }),
   description: z.string().optional(),
-  tickets: z.coerce.number().int().min(1, {
+  base_tickets: z.coerce.number().int().min(1, {
     message: "Tickets must be at least 1",
   }),
   recurrence: z.enum(["daily", "weekly", "monthly"]),
@@ -72,7 +72,7 @@ export function NewChoreDialog({ children, chore, onChoreCreated }: NewChoreDial
     defaultValues: {
       name: chore?.name || "",
       description: chore?.description || "",
-      tickets: chore?.tickets || 5,
+      base_tickets: chore?.base_tickets || 5,
       recurrence: chore?.recurrence || "daily",
       image_url: chore?.image_url || "",
       emoji: chore?.emoji || "",
@@ -174,21 +174,23 @@ export function NewChoreDialog({ children, chore, onChoreCreated }: NewChoreDial
     setIsSubmitting(true);
     
     try {
+      const payload = { ...data, base_tickets: data.base_tickets };
+
       if (isEditMode) {
-        console.log("Sending chore update request:", data);
+        console.log("Sending chore update request:", payload);
         await apiRequest(`/api/chores/${chore.id}`, {
           method: "PUT",
-          body: data
+          body: payload
         });
         toast({
           title: "Chore updated",
           description: "The chore has been updated successfully.",
         });
       } else {
-        console.log("Sending chore create request:", data);
+        console.log("Sending chore create request:", payload);
         await apiRequest("/api/chores", {
-          method: "POST", 
-          body: data
+          method: "POST",
+          body: payload
         });
         toast({
           title: "Chore created",
@@ -269,7 +271,7 @@ export function NewChoreDialog({ children, chore, onChoreCreated }: NewChoreDial
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <FormField
                 control={form.control}
-                name="tickets"
+                name="base_tickets"
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Tickets</FormLabel>

--- a/client/src/pages/bonus-management.tsx
+++ b/client/src/pages/bonus-management.tsx
@@ -366,7 +366,7 @@ export default function BonusManagement() {
                   <SelectContent>
                     {(chores || []).filter((c: Chore) => c.is_active).map((chore: Chore) => (
                       <SelectItem key={chore.id} value={chore.id.toString()}>
-                        {chore.name} ({chore.tickets} tickets)
+                        {chore.name} ({chore.base_tickets} tickets)
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -495,7 +495,7 @@ export default function BonusManagement() {
                                     </SelectItem>
                                     {(chores || []).filter((c: Chore) => c.is_active && c.id !== bonus.assigned_chore_id).map((chore: Chore) => (
                                       <SelectItem key={chore.id} value={chore.id.toString()}>
-                                        {chore.name} ({chore.tickets} tickets)
+                                        {chore.name} ({chore.base_tickets} tickets)
                                       </SelectItem>
                                     ))}
                                   </SelectContent>

--- a/client/src/pages/chores.tsx
+++ b/client/src/pages/chores.tsx
@@ -440,7 +440,7 @@ export default function Chores() {
                             <TableCell className="max-w-xs truncate">
                               {chore.description || "No description"}
                             </TableCell>
-                            <TableCell>{chore.tickets}</TableCell>
+                            <TableCell>{chore.base_tickets}</TableCell>
                             <TableCell>
                               <span className="text-xl">{chore.emoji || "—"}</span>
                             </TableCell>

--- a/client/src/store/chore-store.ts
+++ b/client/src/store/chore-store.ts
@@ -5,7 +5,7 @@ interface Chore {
   id: number;
   name: string;
   description: string;
-  tickets: number;
+  base_tickets: number;
   tier: string;
   is_active: boolean;
   completed?: boolean;


### PR DESCRIPTION
## Summary
- rename the `tickets` property to `base_tickets` across client components
- update forms and store definitions for the new property
- send `base_tickets` when creating or updating chores
- adjust UI to display `base_tickets`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm test`