### PR TITLE
Update logout to clear family users

### DIFF
--- a/client/__tests__/auth-store.test.ts
+++ b/client/__tests__/auth-store.test.ts
@@ -1,0 +1,59 @@
+import { test, expect, beforeEach } from "bun:test";
+
+class LocalStorageMock {
+  private store: Record<string, string> = {};
+  clear() {
+    this.store = {};
+  }
+  getItem(key: string) {
+    return this.store[key] ?? null;
+  }
+  setItem(key: string, value: string) {
+    this.store[key] = String(value);
+  }
+  removeItem(key: string) {
+    delete this.store[key];
+  }
+}
+
+// Provide localStorage before importing the store and keep a reference
+// @ts-ignore
+const storage = new LocalStorageMock();
+// @ts-ignore
+globalThis.localStorage = storage;
+
+let useAuthStore: typeof import("../src/store/auth-store").useAuthStore;
+
+beforeEach(async () => {
+  storage.clear();
+  const mod = await import("../src/store/auth-store");
+  useAuthStore = mod.useAuthStore;
+  useAuthStore.setState({
+    token: null,
+    user: null,
+    originalUser: null,
+    viewingChildId: null,
+    isAuthenticated: false,
+    autoLoginEnabled: true,
+    familyUsers: []
+  });
+});
+
+test("logout clears familyUsers from storage", () => {
+  const store = useAuthStore.getState();
+
+  store.setFamilyUsers([
+    { id: 1, name: "Parent", username: "parent", role: "parent" },
+    { id: 2, name: "Child", username: "child", role: "child" }
+  ] as any);
+
+  // should have stored users
+  let saved = JSON.parse(localStorage.getItem('ticket-tracker-auth') || '{}');
+  expect(saved.state.familyUsers.length).toBe(2);
+
+  store.logout();
+
+  saved = JSON.parse(localStorage.getItem('ticket-tracker-auth') || '{}');
+  expect(Array.isArray(saved.state.familyUsers)).toBe(true);
+  expect(saved.state.familyUsers.length).toBe(0);
+});

--- a/client/src/store/auth-store.ts
+++ b/client/src/store/auth-store.ts
@@ -78,12 +78,13 @@ export const useAuthStore = create<AuthState>()(
       },
       
       logout: () => {
-        set({ 
-          token: null, 
-          user: null, 
+        set({
+          token: null,
+          user: null,
           originalUser: null,
           viewingChildId: null,
-          isAuthenticated: false 
+          isAuthenticated: false,
+          familyUsers: []
         });
       },
       


### PR DESCRIPTION
## Summary
- clear family users on logout
- test logout clears familyUsers from localStorage

## Testing
- `bun test`
- `npm run check` *(fails: Property 'user_id' does not exist on type '{}', etc.)*