### PR TITLE
Load family users during login

### DIFF
--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -68,7 +68,7 @@ export default function Login() {
         description: "Welcome back!",
       });
       
-      login(result.token, result.user);
+      await login(result.token, result.user);
       setLocation("/");
     } catch (error) {
       toast({
@@ -97,7 +97,7 @@ export default function Login() {
         description: "Your account has been created",
       });
       
-      login(result.token, result.user);
+      await login(result.token, result.user);
       setLocation("/");
     } catch (error) {
       toast({


### PR DESCRIPTION
## Summary
- make login async and pull family user list when a parent logs in
- await login in the login page

## Testing
- `npm test`
- `npm run check` *(fails: several pre-existing type errors)*