### PR TITLE
Refactor family login to use apiRequest

### DIFF
--- a/client/src/store/auth-store.ts
+++ b/client/src/store/auth-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import jwtDecode from 'jwt-decode';
+import { apiRequest } from '@/lib/queryClient';
 
 interface UserInfo {
   id: number;
@@ -48,28 +49,17 @@ export const useAuthStore = create<AuthState>()(
       
       loginAsUser: async (username: string) => {
         try {
-          const response = await fetch('/api/auth/login', {
+          const data = await apiRequest('/api/auth/login', {
             method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              username,
-              password: 'password', // For family auto-login
-            }),
+            body: { username, password: 'password' },
           });
-          
-          if (!response.ok) {
-            return false;
-          }
-          
-          const data = await response.json();
-          set({ 
+
+          set({
             token: data.token,
             user: data.user,
-            isAuthenticated: true 
+            isAuthenticated: true,
           });
-          
+
           return true;
         } catch (error) {
           console.error('Auto-login failed:', error);


### PR DESCRIPTION
## Summary
- use `apiRequest` in auth-store for family login

## Testing
- `npm test`