### PR TITLE
Fix schema and vite server type errors

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -23,7 +23,7 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    // allowedHosts is not a valid option here in middleware mode
   };
 
   const vite = await createViteServer({

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -114,7 +114,7 @@ export const insertGoalSchema = createInsertSchema(goals).omit({
 
 export const insertTransactionSchema = createInsertSchema(transactions).omit({
   id: true,
-  date: true,
+  created_at: true,
 });
 
 // Auth schema


### PR DESCRIPTION
## Summary
- fix insertTransactionSchema `omit` field name
- remove invalid `allowedHosts` option in Vite setup

## Testing
- `npm test`
- `npm run check` *(fails: several TypeScript errors remain)*