### PR TITLE
Add child filtering and debug logs

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,7 @@ function ProtectedRoute({ component: Component, ...rest }) {
   const isAuthenticated = useAuthStore(state => state.isAuthenticated);
   const user = useAuthStore(state => state.user);
   const isViewingAsChild = useAuthStore(state => state.isViewingAsChild);
+  console.log('ProtectedRoute: user:', user, 'isAuthenticated:', isAuthenticated, 'isViewingAsChild:', isViewingAsChild());
   
   if (!isAuthenticated) {
     return <Route path="*" component={Login} />;

--- a/client/src/components/account-switcher.tsx
+++ b/client/src/components/account-switcher.tsx
@@ -154,7 +154,9 @@ export function AccountSwitcher() {
             <>
               <DropdownMenuLabel>Family accounts</DropdownMenuLabel>
               {users
-                .filter(user => user.role === 'child')
+                .filter(user =>
+                  user.role === 'child' && (user.name === 'Bryce' || user.name === 'Kiki')
+                )
                 .map(user => (
                   <DropdownMenuItem
                     key={user.id}
@@ -175,7 +177,10 @@ export function AccountSwitcher() {
             <>
               <DropdownMenuLabel>Switch account</DropdownMenuLabel>
               {users
-                .filter(user => user.id !== currentUser.id)
+                .filter(user =>
+                  user.id !== currentUser.id &&
+                  (user.role === 'parent' || user.name === 'Bryce' || user.name === 'Kiki')
+                )
                 .map(user => (
                   <DropdownMenuItem
                     key={user.id}

--- a/client/src/components/family-user-selector.tsx
+++ b/client/src/components/family-user-selector.tsx
@@ -34,7 +34,9 @@ export function FamilyUserSelector() {
 
   // Filter parent and child users
   const parentUsers = users.filter((user: UserInfo) => user.role === 'parent');
-  const childUsers = users.filter((user: UserInfo) => user.role === 'child');
+  const childUsers = users.filter((user: UserInfo) =>
+    user.role === 'child' && (user.name === 'Bryce' || user.name === 'Kiki')
+  );
 
   // Handle user login
   const handleUserLogin = async (username: string) => {

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -67,6 +67,7 @@ export function Sidebar() {
   };
   
   const handleSwitchToChild = (childUser: UserInfo) => {
+    console.log('Sidebar: handleSwitchToChild called with:', childUser);
     // If already viewing as a child and trying to switch to another child,
     // we need to reset to parent view first, then switch to the new child
     if (viewingAsChild) {
@@ -82,8 +83,9 @@ export function Sidebar() {
       setLocation('/');
     }
   };
-  
+
   const handleResetToParent = () => {
+    console.log('Sidebar: handleResetToParent called.');
     resetChildView();
     setLocation('/');
   };

--- a/client/src/components/user-switcher.tsx
+++ b/client/src/components/user-switcher.tsx
@@ -40,7 +40,9 @@ export function UserSwitcher() {
   });
   
   // Only child users
-  const childUsers = users.filter(user => user.role === 'child');
+  const childUsers = users.filter(
+    user => user.role === 'child' && (user.name === 'Bryce' || user.name === 'Kiki')
+  );
   
   useEffect(() => {
     // If coming back from children view, reset selection

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -163,7 +163,20 @@ export default function Dashboard() {
     balance: number;
     activeGoal?: {
       id: number;
-      product: any;
+      user_id: number;
+      product_id: number;
+      tickets_saved: number;
+      is_active: boolean;
+      product: {
+        id: number;
+        title: string;
+        asin: string;
+        image_url: string;
+        price_cents: number;
+        price_locked_cents: number;
+      };
+      progress: number;
+      estimatedCompletion?: { days: number; weeks: number; };
     };
     chores?: any[];
   }

--- a/client/src/store/auth-store.ts
+++ b/client/src/store/auth-store.ts
@@ -155,12 +155,14 @@ export const useAuthStore = create<AuthState>()(
       // Switch to viewing as a child user
       switchChildView: (childUser: UserInfo) => {
         const { user } = get();
-        
+
         // Only parents can switch to child view
         if (user?.role !== 'parent') return;
-        
+
+        console.log('AuthStore: switchChildView called for:', childUser);
+
         // Store the original parent user
-        set({ 
+        set({
           originalUser: user,
           user: childUser,
           viewingChildId: childUser.id
@@ -170,10 +172,12 @@ export const useAuthStore = create<AuthState>()(
       // Reset back to parent view
       resetChildView: () => {
         const { originalUser } = get();
-        
+
+        console.log('AuthStore: resetChildView called. Original user:', originalUser);
+
         // If there's an original user, switch back
         if (originalUser) {
-          set({ 
+          set({
             user: originalUser,
             originalUser: null,
             viewingChildId: null
@@ -190,7 +194,9 @@ export const useAuthStore = create<AuthState>()(
       // Get all child users from family users
       getChildUsers: () => {
         const { familyUsers } = get();
-        return familyUsers.filter(user => user.role === 'child');
+        return familyUsers.filter(
+          user => user.role === 'child' && (user.name === 'Kiki' || user.name === 'Bryce')
+        );
       },
       
       // Get the ID of the active child (either current user if child, or viewingChildId if parent looking as child)

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -909,6 +909,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         };
 
         // Broadcast to WebSocket clients
+        console.log('[BROADCAST DEBUG] Broadcasting transaction:earn with user_id:', transaction.user_id, 'Full transaction object:', transaction);
         broadcast("transaction:earn", {
           data: {
             id: transaction.id,


### PR DESCRIPTION
## Summary
- filter `getChildUsers` to only return Bryce and Kiki
- add debug logging when switching accounts in auth store and sidebar
- log auth info in `ProtectedRoute`
- add broadcast debug log in server
- extend dashboard `StatsResponse` typing
- apply same child filtering to account switcher, family user selector and user switcher

## Testing
- `npm test`