### PR TITLE
Refactor wishlist to family catalog

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,7 +11,7 @@ import Dashboard from "@/pages/dashboard";
 import ParentDashboard from "@/pages/parent-dashboard";
 import Login from "@/pages/login";
 import Chores from "@/pages/chores";
-import Wishlist from "@/pages/wishlist";
+import FamilyCatalogPage from "@/pages/family-catalog"; // Renamed import
 import Transactions from "@/pages/transactions";
 import BonusManagement from "@/pages/bonus-management";
 import DebugPage from "@/pages/debug";
@@ -65,8 +65,8 @@ function Router() {
       <Route path="/chores">
         <ProtectedRoute component={Chores} />
       </Route>
-      <Route path="/wishlist">
-        <ProtectedRoute component={Wishlist} />
+      <Route path="/family-catalog"> {/* Renamed path */}
+        <ProtectedRoute component={FamilyCatalogPage} /> {/* Use renamed component */}
       </Route>
       <Route path="/transactions">
         <ProtectedRoute component={Transactions} />

--- a/client/src/components/layout/mobile-nav.tsx
+++ b/client/src/components/layout/mobile-nav.tsx
@@ -21,7 +21,7 @@ import {
 const navItems = [
   { path: "/", label: "Home", icon: "ri-dashboard-line" },
   { path: "/chores", label: "Chores", icon: "ri-list-check-2" },
-  { path: "/wishlist", label: "Wishes", icon: "ri-gift-line" },
+  { path: "/family-catalog", label: "Catalog", icon: "ri-store-2-line" }, // Renamed (shortened for mobile)
   { path: "/transactions", label: "Tickets", icon: "ri-exchange-funds-line" },
 ];
 

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -20,7 +20,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 const navItems = [
   { path: "/", label: "Dashboard", icon: "ri-dashboard-line" },
   { path: "/chores", label: "Chores", icon: "ri-list-check-2" },
-  { path: "/wishlist", label: "Wishlist", icon: "ri-gift-line" },
+  { path: "/family-catalog", label: "Family Catalog", icon: "ri-store-2-line" }, // Renamed
   { path: "/transactions", label: "Transactions", icon: "ri-exchange-funds-line" },
 ];
 

--- a/client/src/components/progress-card.tsx
+++ b/client/src/components/progress-card.tsx
@@ -88,7 +88,7 @@ export default function ProgressCard({ goal, onRefresh }: ProgressCardProps) {
   const handleSwitchGoal = () => {
     try {
       // Navigate directly to the wishlist page with my-list tab active
-      navigate("/wishlist?tab=my-list");
+      navigate("/family-catalog?tab=my-list");
       
       toast({
         title: "Switch Goals",

--- a/client/src/components/shared-catalog.tsx
+++ b/client/src/components/shared-catalog.tsx
@@ -19,8 +19,8 @@ interface SharedCatalogProps {
 }
 
 export function SharedCatalog({ onProductSelected }: SharedCatalogProps) {
-  const { user } = useAuthStore();
-  const isParent = user?.role === 'parent';
+  const { user, isViewingAsChild } = useAuthStore();
+  const canManageCatalog = user?.role === 'parent' && !isViewingAsChild(); // Parent managing, not viewing as child
   
   // Get all available products
   const { data: products = [] } = useQuery({
@@ -39,7 +39,7 @@ export function SharedCatalog({ onProductSelected }: SharedCatalogProps) {
     <div className="space-y-4">
       <div className="flex justify-between items-center">
         <h2 className="text-xl font-bold">Family Catalog</h2>
-        {isParent && (
+        {canManageCatalog && (
           <AddProductDialog onProductAdded={refreshCatalog}>
             <Button size="sm">
               <Gift className="mr-2 h-4 w-4" />
@@ -56,7 +56,7 @@ export function SharedCatalog({ onProductSelected }: SharedCatalogProps) {
           <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
             Products added to the catalog will be available for everyone in the family.
           </p>
-          {isParent && (
+          {canManageCatalog && (
             <AddProductDialog onProductAdded={refreshCatalog}>
               <Button>
                 <Gift className="mr-2 h-4 w-4" />
@@ -99,7 +99,7 @@ export function SharedCatalog({ onProductSelected }: SharedCatalogProps) {
                   </div>
                 </CardContent>
                 <CardFooter className="p-4 pt-0 flex justify-between">
-                  {isParent && (
+                  {canManageCatalog && (
                     <div className="flex space-x-2">
                       <EditProductDialog 
                         product={product} 
@@ -123,10 +123,13 @@ export function SharedCatalog({ onProductSelected }: SharedCatalogProps) {
                       </DeleteProductDialog>
                     </div>
                   )}
+                  {/* Children (or parent viewing as child) see "Add to My Wishlist" */}
+                  {!canManageCatalog && (
                   <Button size="sm" variant="secondary" onClick={() => handleAddToWishlist(product.id)}>
                     Add to Wishlist
                     <ArrowRight className="ml-2 h-4 w-4" />
                   </Button>
+                  )}
                 </CardFooter>
               </Card>
             ))}

--- a/client/src/pages/family-catalog.tsx
+++ b/client/src/pages/family-catalog.tsx
@@ -14,13 +14,14 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PlusIcon, ShoppingBag } from "lucide-react";
 
-export default function Wishlist() {
-  const { user } = useAuthStore();
+export default function FamilyCatalogPage() {
+  const { user, isViewingAsChild } = useAuthStore();
   const { toast } = useToast();
   const [location] = useLocation();
   
-  // Default to "my-list" tab unless otherwise specified
-  const [activeTab, setActiveTab] = useState("my-list");
+  // Default tab logic based on role
+  const isParentView = user?.role === 'parent' && !isViewingAsChild();
+  const [activeTab, setActiveTab] = useState(isParentView ? "catalog" : "my-list");
   
   // No URL parameter handling for now - just use the default tab
   // We'll add this feature back once we resolve the type issues
@@ -209,11 +210,18 @@ export default function Wishlist() {
       <div className="p-4 md:p-6 max-w-7xl mx-auto">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
           <TabsList className="mb-4">
-            <TabsTrigger value="my-list">My Wishlist</TabsTrigger>
+            {/* Conditional Tabs for Parent vs Child */}
+            {!isParentView && (
+              <>
+                <TabsTrigger value="my-list">My Wishlist</TabsTrigger>
+                <TabsTrigger value="active-goal" disabled={!activeGoal}>Active Goal</TabsTrigger>
+              </>
+            )}
             <TabsTrigger value="catalog">Family Catalog</TabsTrigger>
-            <TabsTrigger value="active-goal" disabled={!activeGoal}>Active Goal</TabsTrigger>
           </TabsList>
 
+          {/* My Wishlist Tab - Only for Children or Parent viewing as Child */}
+          {!isParentView && (
           <TabsContent value="my-list">
             {isLoading ? (
               <div className="flex justify-center my-12">
@@ -270,11 +278,18 @@ export default function Wishlist() {
               </>
             )}
           </TabsContent>
+          )}
 
           <TabsContent value="catalog">
-            <SharedCatalog onProductSelected={handleAddToWishlist} />
+            {/* When parent views catalog, onProductSelected might not be needed, or could have different meaning */}
+            {/* For children, onProductSelected adds to their personal wishlist */}
+            <SharedCatalog 
+              onProductSelected={isParentView ? () => {} : handleAddToWishlist} 
+            />
           </TabsContent>
 
+          {/* Active Goal Tab - Only for Children or Parent viewing as Child */}
+          {!isParentView && activeGoal && (
           <TabsContent value="active-goal">
             {activeGoal && (
               <div className="grid grid-cols-1 gap-4">
@@ -305,6 +320,7 @@ export default function Wishlist() {
               </div>
             )}
           </TabsContent>
+          )}
         </Tabs>
       </div>
     </>

--- a/client/src/pages/parent-dashboard.tsx
+++ b/client/src/pages/parent-dashboard.tsx
@@ -3,18 +3,17 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { useAuthStore } from "@/store/auth-store";
-import { useStatsStore } from "@/store/stats-store";
-import { createWebSocketConnection, subscribeToChannel } from "@/lib/websocketClient";
-import TransactionsTable from "@/components/transactions-table";
+import { createWebSocketConnection, subscribeToChannel } from "@/lib/websocketClient"; // Corrected import
+import TransactionsTable from "@/components/transactions-table"; // Keep if needed
 import { NewChoreDialog } from "@/components/new-chore-dialog";
 import { BadBehaviorDialog } from "@/components/bad-behavior-dialog";
 import { GoodBehaviorDialog } from "@/components/good-behavior-dialog";
 import { DailyBonusWheel } from "@/components/daily-bonus-wheel";
-import { PurchaseDialog } from "@/components/purchase-dialog";
+import { AddProductDialog } from "@/components/add-product-dialog"; // For adding to catalog
 import ChildProfileCard from "@/components/child-profile-card";
 import ProfileImageModal from "@/components/profile-image-modal";
 import { Button } from "@/components/ui/button";
-import { PlusIcon, UserIcon, MinusCircleIcon, PlusCircleIcon, ShoppingCartIcon, BarChart3Icon, ImageIcon } from "lucide-react";
+import { PlusIcon, UserIcon, MinusCircleIcon, PlusCircleIcon, ImageIcon } from "lucide-react";
 import { format } from "date-fns";
 
 export default function ParentDashboard() {
@@ -262,7 +261,31 @@ export default function ParentDashboard() {
                 user={selectedChild}
               />
             )}
-            
+
+            {/* Family Catalog Quick Actions Section */}
+            <section className="mb-8">
+              <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm overflow-hidden">
+                <div className="p-6">
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Family Catalog</h3>
+                  <div className="flex flex-wrap gap-3">
+                    <AddProductDialog onProductAdded={() => queryClient.invalidateQueries({ queryKey: ["/api/products"] })}>
+                      <Button variant="outline">
+                        <PlusIcon className="mr-2 h-4 w-4" />
+                        Add New Product to Catalog
+                      </Button>
+                    </AddProductDialog>
+                    <Button 
+                      variant="default" 
+                      onClick={() => window.location.href = '/family-catalog'} // Simple navigation
+                    >
+                      View & Manage Full Catalog
+                    </Button>
+                  </div>
+                  {/* Optional: Display a few recent/highlighted catalog items here later */}
+                </div>
+              </div>
+            </section>
+
             {/* Daily Bonus Wheel Management */}
             <section className="mb-8">
               <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm overflow-hidden">


### PR DESCRIPTION
## Summary
- rename wishlist page to `family-catalog.tsx` and adjust routes
- update sidebar/mobile navigation to point at Family Catalog
- adjust catalog logic for parent vs child views
- tweak parent dashboard to include Family Catalog quick actions
- update progress-card navigation path

## Testing
- `npm test`
- `npm run check` *(fails: TS errors)*