### PR TITLE
Fix transaction page imports

### DIFF
--- a/client/src/pages/transactions.tsx
+++ b/client/src/pages/transactions.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useAuthStore } from "@/store/auth-store";
+import { useAuthStore, type UserInfo } from "@/store/auth-store";
 import { useStatsStore } from "@/store/stats-store";
 import { subscribeToChannel } from "@/lib/websocketClient";
 import TransactionsTable from "@/components/transactions-table";
@@ -37,12 +37,6 @@ export default function Transactions() {
   const isParent = user?.role === "parent";
   
   // Fetch users if current user is a parent
-  interface UserInfo {
-    id: number;
-    name: string;
-    role: string;
-  }
-
   const { data: users = [] } = useQuery<UserInfo[]>({
     queryKey: ["/api/users"],
     enabled: isParent,


### PR DESCRIPTION
## Summary
- avoid re-declaring `UserInfo` in transactions page
- ensure imports are at module scope

## Testing
- `npm run build`
- `npm run check` *(fails: multiple existing type errors)*