### PR TITLE
Improve child dashboard header

### DIFF
--- a/client/src/components/child-dashboard-header.tsx
+++ b/client/src/components/child-dashboard-header.tsx
@@ -33,15 +33,14 @@ export default function ChildDashboardHeader({ activeGoal }: ChildDashboardHeade
   return (
     <div className="mb-6 flex items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm">
       <div className="flex items-center space-x-4">
-        <div className="relative w-14 h-14">
-          <ProgressRing percent={progress} size={56} strokeWidth={4} color="#fbbf24" />
-          <Avatar className="h-10 w-10 absolute inset-0 m-auto border">
+        <ProgressRing percent={progress} size={64} strokeWidth={6} color="#fbbf24">
+          <Avatar className="h-12 w-12 border">
             <AvatarImage src={user.profile_image_url || undefined} alt={user.name} />
             <AvatarFallback className="bg-primary-600 text-white text-sm">
               {getInitials(user.name)}
             </AvatarFallback>
           </Avatar>
-        </div>
+        </ProgressRing>
         <div>
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
             {user.name}
@@ -53,8 +52,8 @@ export default function ChildDashboardHeader({ activeGoal }: ChildDashboardHeade
                 {balance}
               </span>
             </div>
-            <span className="text-xs text-pink-600 dark:text-purple-400">
-              {ticketsToUSD(balance)}
+            <span className="text-xs text-muted-foreground">
+              ({ticketsToUSD(balance)})
             </span>
           </div>
         </div>

--- a/client/src/components/mobile-section-tabs.tsx
+++ b/client/src/components/mobile-section-tabs.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import clsx from "clsx";
+
+const SECTIONS = [
+  { id: "chores", label: "Chores" },
+  { id: "activity", label: "Activity" },
+];
+
+export default function MobileSectionTabs() {
+  const [active, setActive] = useState<string>(SECTIONS[0].id);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: "-50% 0px -50% 0px" }
+    );
+    SECTIONS.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <nav className="sticky top-[var(--app-header-h)] bg-background z-20 flex gap-6 justify-center text-sm py-2 border-b">
+      {SECTIONS.map(({ id, label }) => (
+        <a
+          key={id}
+          href={`#${id}`}
+          className={clsx(
+            "pb-1",
+            active === id
+              ? "font-semibold text-primary border-b-2 border-primary"
+              : "text-muted-foreground"
+          )}
+        >
+          {label}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/client/src/components/ui/progress-ring.tsx
+++ b/client/src/components/ui/progress-ring.tsx
@@ -1,18 +1,20 @@
 import { motion } from "framer-motion";
+import type { ReactNode } from "react";
 
 interface ProgressRingProps {
   percent: number;
   size?: number;
   strokeWidth?: number;
   color?: string;
+  children?: ReactNode;
 }
 
-export function ProgressRing({ percent, size = 64, strokeWidth = 4, color = "#10b981" }: ProgressRingProps) {
+export function ProgressRing({ percent, size = 64, strokeWidth = 4, color = "#10b981", children }: ProgressRingProps) {
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference * (1 - Math.min(100, Math.max(0, percent)) / 100);
 
-  return (
+  const ring = (
     <svg width={size} height={size} className="block">
       <circle
         stroke="currentColor"
@@ -38,6 +40,19 @@ export function ProgressRing({ percent, size = 64, strokeWidth = 4, color = "#10
         transition={{ ease: "easeOut", duration: 0.5 }}
       />
     </svg>
+  );
+
+  if (!children) {
+    return ring;
+  }
+
+  return (
+    <div style={{ width: size, height: size }} className="relative">
+      {ring}
+      <div className="absolute inset-0 flex items-center justify-center">
+        {children}
+      </div>
+    </div>
   );
 }
 export default ProgressRing;

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -10,6 +10,7 @@ import ProgressCard from "@/components/progress-card";
 import ChoreCard from "@/components/chore-card";
 import TransactionsTable from "@/components/transactions-table";
 import ChildDashboardHeader from "@/components/child-dashboard-header";
+import MobileSectionTabs from "@/components/mobile-section-tabs";
 import { NewChoreDialog } from "@/components/new-chore-dialog";
 import { BadBehaviorDialog } from "@/components/bad-behavior-dialog";
 import { GoodBehaviorDialog } from "@/components/good-behavior-dialog";
@@ -536,6 +537,9 @@ export default function Dashboard() {
   // Handle earn transaction completion (from child components)
   const handleChoreComplete = async (choreId: number) => {
     try {
+      navigator.vibrate?.(24);
+    } catch {}
+    try {
       // If we're viewing as a child, include the userId in the request
       const payload: any = { chore_id: choreId };
       
@@ -719,7 +723,12 @@ export default function Dashboard() {
           </Alert>
         )}
 
-        {!isParentView && <ChildDashboardHeader activeGoal={data?.activeGoal} />}
+        {!isParentView && (
+          <>
+            <ChildDashboardHeader activeGoal={data?.activeGoal} />
+            <MobileSectionTabs />
+          </>
+        )}
         
         {isLoading ? (
           <div className="flex justify-center my-12">
@@ -734,42 +743,11 @@ export default function Dashboard() {
                   <div className="flex items-center justify-between mb-4">
                     <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Savings Progress</h3>
                     <div className="flex items-center gap-4">
-                      {/* Enhanced ticket balance display with larger graphics */}
-                      <div className="flex items-center bg-gradient-to-r from-amber-50 to-amber-100 dark:from-amber-900/30 dark:to-amber-800/20 px-4 py-3 rounded-lg border border-amber-200 dark:border-amber-800/50 shadow-sm">
-                        <div className="relative mr-3">
-                          <div className="relative">
-                            <Ticket className="h-12 w-12 text-amber-500 dark:text-amber-400" strokeWidth={1.5} />
-                            <div className="absolute inset-0 flex items-center justify-center">
-                              <span className="text-xl font-bold text-amber-700 dark:text-amber-300">
-                                {balance || data?.balance || 0}
-                              </span>
-                            </div>
-                          </div>
-                          <div className="absolute -right-1 -top-1">
-                            <span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary-500 text-[10px] font-bold text-white ring-2 ring-white dark:ring-gray-800">
-                              {user?.role === 'child' ? '🎯' : '👑'}
-                            </span>
-                          </div>
-                        </div>
-                        
-                        <div className="flex flex-col">
-                          <span className="text-xs uppercase tracking-wider text-amber-700/80 dark:text-amber-400/80 font-medium">
-                            Current Balance
-                          </span>
-                          <span className="text-lg font-bold text-amber-800 dark:text-amber-300">
-                            {balance || data?.balance || 0} Tickets
-                          </span>
-                          <span className="text-xs text-amber-600/80 dark:text-amber-500/80">
-                            Worth: ${((balance || data?.balance || 0) * TICKET_DOLLAR_VALUE).toFixed(2)} USD
-                          </span>
-                        </div>
-                      </div>
-                      
                       {/* Purchase Button - Only show for child or when viewing as child */}
                       {(viewingChild || user?.role === 'child') && (
                         <PurchaseDialog onCompleted={() => refetch()}>
-                          <Button 
-                            variant="outline" 
+                          <Button
+                            variant="outline"
                             size="default"
                             className="flex items-center text-primary-600 border-primary-200 hover:bg-primary-50 hover:text-primary-700 dark:text-primary-400 dark:border-primary-900 dark:hover:bg-primary-950 dark:hover:text-primary-300 h-12"
                           >

--- a/client/src/pages/new-dashboard.tsx
+++ b/client/src/pages/new-dashboard.tsx
@@ -18,6 +18,7 @@ import { PurchaseDialog } from "@/components/purchase-dialog";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { PlusIcon, UserIcon, MinusCircleIcon, PlusCircleIcon, ShoppingCartIcon, BarChart3Icon } from "lucide-react";
+import MobileSectionTabs from "@/components/mobile-section-tabs";
 import { format } from "date-fns";
 
 export default function Dashboard() {
@@ -311,6 +312,10 @@ export default function Dashboard() {
   // Handle when a chore is completed (regular chore)
   const handleChoreComplete = async (choreId: number) => {
     console.log(`Chore ${choreId} completed. Updating UI.`);
+
+    try {
+      navigator.vibrate?.(24);
+    } catch {}
     
     // We don't need to manually update the UI here because:
     // 1. The server will emit a transaction:earn WebSocket event
@@ -419,6 +424,7 @@ export default function Dashboard() {
           </div>
         ) : (
           <>
+            <MobileSectionTabs />
             {/* Parent Dashboard - Only visible when not viewing a child */}
             {user?.role === 'parent' && !viewingChild ? (
               <>
@@ -520,14 +526,9 @@ export default function Dashboard() {
                       <div className="flex items-center justify-between mb-4">
                         <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Savings Progress</h3>
                         <div className="flex items-center gap-4">
-                          <span className="text-sm text-gray-500 dark:text-gray-400">
-                            Current Balance: <span className="font-semibold text-primary-600 dark:text-primary-400">
-                              {balance || data?.balance || 0} tickets
-                            </span>
-                          </span>
                           <PurchaseDialog onCompleted={() => refetch()}>
-                            <Button 
-                              variant="outline" 
+                            <Button
+                              variant="outline"
                               size="sm"
                               className="flex items-center text-primary-600 border-primary-200 hover:bg-primary-50 hover:text-primary-700 dark:text-primary-400 dark:border-primary-900 dark:hover:bg-primary-950 dark:hover:text-primary-300"
                             >


### PR DESCRIPTION
## Summary
- support children within `ProgressRing` so avatar fits inside
- convert child dashboard header to use `ProgressRing` hero
- add sticky `MobileSectionTabs` navigation
- remove duplicated balance card and show balance under tickets
- vibrate when chores complete

## Testing
- `npm test`