### PR TITLE
Enhance mobile UX with swipe actions and sticky tabs

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,7 +19,7 @@ import DebugPage from "@/pages/debug";
 import { useAuthStore } from "./store/auth-store";
 import { Sidebar } from "./components/layout/sidebar";
 import { MobileNav } from "./components/layout/mobile-nav";
-import FloatingExitPill from "./components/layout/floating-exit-pill";
+import FloatingExitFab from "./components/layout/floating-exit-fab";
 
 function ProtectedRoute({ component: Component, ...rest }) {
   const isAuthenticated = useAuthStore(state => state.isAuthenticated);
@@ -53,7 +53,7 @@ function AppLayout({ children }) {
         {children}
       </main>
       <MobileNav />
-      <FloatingExitPill />
+      <FloatingExitFab />
     </div>
   );
 }

--- a/client/src/components/chore-card.tsx
+++ b/client/src/components/chore-card.tsx
@@ -7,7 +7,7 @@ import { CheckCircle, Award } from "lucide-react";
 import { BonusBadge } from "@/components/bonus-badge";
 import { useMobile } from "@/context/MobileContext";
 
-interface ChoreCardProps {
+export interface ChoreCardProps {
   chore: {
     id: number;
     name: string;

--- a/client/src/components/layout/floating-exit-fab.tsx
+++ b/client/src/components/layout/floating-exit-fab.tsx
@@ -1,0 +1,27 @@
+import { ArrowLeft } from "lucide-react";
+import { useLocation } from "wouter";
+import { useAuthStore } from "@/store/auth-store";
+import { Button } from "@/components/ui/button";
+
+export default function FloatingExitFab() {
+  const viewingChildId = useAuthStore(s => s.viewingChildId);
+  const resetChildView = useAuthStore(s => s.resetChildView);
+  const [, navigate] = useLocation();
+
+  if (!viewingChildId) return null;
+
+  const handleClick = () => {
+    resetChildView();
+    navigate("/");
+  };
+
+  return (
+    <Button
+      onClick={handleClick}
+      aria-label="Return to Parent"
+      className="fixed bottom-4 left-4 z-50 rounded-full p-3 shadow bg-primary text-white hover:bg-primary/90"
+    >
+      <ArrowLeft className="h-5 w-5" />
+    </Button>
+  );
+}

--- a/client/src/components/mobile-section-tabs.tsx
+++ b/client/src/components/mobile-section-tabs.tsx
@@ -28,7 +28,7 @@ export default function MobileSectionTabs() {
   }, []);
 
   return (
-    <nav className="sticky top-[var(--app-header-h)] bg-background z-20 flex gap-6 justify-center text-sm py-2 border-b">
+    <nav className="child-tabs bg-background flex gap-6 justify-center text-sm py-2 border-b">
       {SECTIONS.map(({ id, label }) => (
         <a
           key={id}

--- a/client/src/components/swipeable-chore-card.tsx
+++ b/client/src/components/swipeable-chore-card.tsx
@@ -1,0 +1,26 @@
+import { useRef } from "react";
+import ChoreCard, { type ChoreCardProps } from "./chore-card";
+
+export default function SwipeableChoreCard(props: ChoreCardProps) {
+  const startX = useRef<number | null>(null);
+
+  const onStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    startX.current = e.touches[0].clientX;
+  };
+
+  const onEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (startX.current === null) return;
+    const diff = e.changedTouches[0].clientX - startX.current;
+    if (diff > 60) {
+      props.onComplete(props.chore.id).catch(() => {});
+      if (navigator.vibrate) navigator.vibrate(20);
+    }
+    startX.current = null;
+  };
+
+  return (
+    <div onTouchStart={onStart} onTouchEnd={onEnd}>
+      <ChoreCard {...props} />
+    </div>
+  );
+}

--- a/client/src/components/transactions-mobile.tsx
+++ b/client/src/components/transactions-mobile.tsx
@@ -1,0 +1,10 @@
+import TransactionsTable from "./transactions-table";
+import type { TransactionsTableProps } from "./transactions-table";
+
+export default function TransactionsMobile(props: TransactionsTableProps) {
+  return (
+    <div className="sm:hidden">
+      <TransactionsTable {...props} />
+    </div>
+  );
+}

--- a/client/src/components/transactions-table-desktop.tsx
+++ b/client/src/components/transactions-table-desktop.tsx
@@ -1,0 +1,10 @@
+import TransactionsTable from "./transactions-table";
+import type { TransactionsTableProps } from "./transactions-table";
+
+export default function TransactionsTableDesktop(props: TransactionsTableProps) {
+  return (
+    <div className="hidden sm:block">
+      <TransactionsTable {...props} />
+    </div>
+  );
+}

--- a/client/src/components/transactions-table.tsx
+++ b/client/src/components/transactions-table.tsx
@@ -31,7 +31,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { subscribeToChannel } from "@/lib/websocketClient";
 import { useLocation } from "wouter";
 
-interface TransactionsTableProps {
+export interface TransactionsTableProps {
   userId?: string;
   limit?: number;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -112,4 +112,10 @@
     animation: shadow-pulse 1.5s ease-in-out infinite;
     filter: drop-shadow(0 0 8px rgba(253, 224, 71, 0.7));
   }
+
+  .child-tabs {
+    position: sticky;
+    top: calc(var(--app-header-h) + 8px);
+    z-index: 30;
+  }
 }

--- a/client/src/pages/chores.tsx
+++ b/client/src/pages/chores.tsx
@@ -6,7 +6,7 @@ import { queryClient } from "@/lib/queryClient";
 import { useAuthStore } from "@/store/auth-store";
 import { useStatsStore } from "@/store/stats-store";
 import { createWebSocketConnection, subscribeToChannel } from "@/lib/websocketClient";
-import ChoreCard from "@/components/chore-card";
+import SwipeableChoreCard from "@/components/swipeable-chore-card";
 import { SpinPromptModal } from "@/components/spin-prompt-modal";
 import { ChildBonusWheel } from "@/components/child-bonus-wheel";
 import { NewChoreDialog } from "@/components/new-chore-dialog";
@@ -405,10 +405,10 @@ export default function Chores() {
                   chores
                     .filter((chore: Chore) => chore.is_active)
                     .map((chore: Chore) => (
-                      <ChoreCard 
-                        key={chore.id} 
-                        chore={chore} 
-                        onComplete={handleChoreComplete} 
+                      <SwipeableChoreCard
+                        key={chore.id}
+                        chore={chore}
+                        onComplete={handleChoreComplete}
                       />
                     ))
                 ) : (

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -7,8 +7,9 @@ import { TICKET_DOLLAR_VALUE } from "../../../config/business";
 import { useStatsStore } from "@/store/stats-store";
 import { createWebSocketConnection, subscribeToChannel, sendMessage } from "@/lib/websocketClient";
 import ProgressCard from "@/components/progress-card";
-import ChoreCard from "@/components/chore-card";
-import TransactionsTable from "@/components/transactions-table";
+import SwipeableChoreCard from "@/components/swipeable-chore-card";
+import TransactionsMobile from "@/components/transactions-mobile";
+import TransactionsTableDesktop from "@/components/transactions-table-desktop";
 import ChildDashboardHeader from "@/components/child-dashboard-header";
 import MobileSectionTabs from "@/components/mobile-section-tabs";
 import { NewChoreDialog } from "@/components/new-chore-dialog";
@@ -808,9 +809,9 @@ export default function Dashboard() {
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 {data?.chores && data.chores.length > 0 ? (
                   data.chores.map(chore => (
-                    <ChoreCard 
-                      key={chore.id} 
-                      chore={chore} 
+                    <SwipeableChoreCard
+                      key={chore.id}
+                      chore={chore}
                       onComplete={handleChoreComplete}
                       onBonusComplete={handleBonusChoreComplete}
                     />
@@ -839,10 +840,12 @@ export default function Dashboard() {
                 </a>
               </div>
               
-              <TransactionsTable limit={5} />
+              <TransactionsMobile limit={5} />
+              <TransactionsTableDesktop limit={5} />
             </section>
             
-            {/* WebSocket Debug Panel - visible to all users for testing */}
+            {/* WebSocket Debug Panel - visible only in development */}
+            {import.meta.env.DEV && (
               <section className="mt-8 p-4 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
                 <div className="flex items-center justify-between mb-2">
                   <h3 className="text-lg font-semibold flex items-center gap-2">
@@ -886,6 +889,7 @@ export default function Dashboard() {
                   <p className="text-sm text-gray-500 dark:text-gray-400">No WebSocket events received yet. Try refreshing or performing an action.</p>
                 )}
               </section>
+            )}
             </>
           )}
       </div>

--- a/client/src/pages/new-dashboard.tsx
+++ b/client/src/pages/new-dashboard.tsx
@@ -6,8 +6,9 @@ import { useAuthStore } from "@/store/auth-store";
 import { useStatsStore } from "@/store/stats-store";
 import { createWebSocketConnection, subscribeToChannel, sendMessage } from "@/lib/websocketClient";
 import ProgressCard from "@/components/progress-card";
-import ChoreCard from "@/components/chore-card";
-import TransactionsTable from "@/components/transactions-table";
+import SwipeableChoreCard from "@/components/swipeable-chore-card";
+import TransactionsMobile from "@/components/transactions-mobile";
+import TransactionsTableDesktop from "@/components/transactions-table-desktop";
 import { NewChoreDialog } from "@/components/new-chore-dialog";
 import { BadBehaviorDialog } from "@/components/bad-behavior-dialog";
 import { GoodBehaviorDialog } from "@/components/good-behavior-dialog";
@@ -511,7 +512,8 @@ export default function Dashboard() {
                           View All
                         </a>
                       </div>
-                      <TransactionsTable limit={10} />
+                      <TransactionsMobile limit={10} />
+                      <TransactionsTableDesktop limit={10} />
                     </div>
                   </div>
                 </section>
@@ -569,9 +571,9 @@ export default function Dashboard() {
                   <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                     {data?.chores && data.chores.length > 0 ? (
                       data.chores.map(chore => (
-                        <ChoreCard 
-                          key={chore.id} 
-                          chore={chore} 
+                        <SwipeableChoreCard
+                          key={chore.id}
+                          chore={chore}
                           onComplete={handleChoreComplete}
                           onBonusComplete={handleBonusChoreComplete}
                         />
@@ -593,7 +595,8 @@ export default function Dashboard() {
                     </a>
                   </div>
                   
-                  <TransactionsTable limit={5} />
+                  <TransactionsMobile limit={5} />
+                  <TransactionsTableDesktop limit={5} />
                 </section>
               </>
             )}

--- a/client/src/pages/parent-dashboard.tsx
+++ b/client/src/pages/parent-dashboard.tsx
@@ -4,7 +4,8 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { useAuthStore } from "@/store/auth-store";
 import { createWebSocketConnection, subscribeToChannel } from "@/lib/websocketClient"; // Corrected import
-import TransactionsTable from "@/components/transactions-table"; // Keep if needed
+import TransactionsMobile from "@/components/transactions-mobile";
+import TransactionsTableDesktop from "@/components/transactions-table-desktop";
 import { NewChoreDialog } from "@/components/new-chore-dialog";
 import { BadBehaviorDialog } from "@/components/bad-behavior-dialog";
 import { GoodBehaviorDialog } from "@/components/good-behavior-dialog";
@@ -311,7 +312,8 @@ export default function ParentDashboard() {
                       <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary-600"></div>
                     </div>
                   ) : (
-                    <TransactionsTable limit={10} />
+                    <TransactionsMobile limit={10} />
+                    <TransactionsTableDesktop limit={10} />
                   )}
                 </div>
               </div>

--- a/client/src/pages/transactions.tsx
+++ b/client/src/pages/transactions.tsx
@@ -3,7 +3,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore, type UserInfo } from "@/store/auth-store";
 import { useStatsStore } from "@/store/stats-store";
 import { subscribeToChannel } from "@/lib/websocketClient";
-import TransactionsTable from "@/components/transactions-table";
+import TransactionsMobile from "@/components/transactions-mobile";
+import TransactionsTableDesktop from "@/components/transactions-table-desktop";
 import { 
   Card, 
   CardContent, 
@@ -214,7 +215,8 @@ export default function Transactions() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <TransactionsTable userId={userId} limit={25} />
+            <TransactionsMobile userId={userId} limit={25} />
+            <TransactionsTableDesktop userId={userId} limit={25} />
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- add swipeable chore card component and use it
- introduce floating exit FAB shown when viewing child
- support responsive transaction components and wrappers
- make mobile tabs sticky via new `child-tabs` style
- guard websocket monitor to dev only

## Testing
- `npm test --silent`