### PR TITLE
Implement UI polish and swipe features

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import ErrorBoundary from "./components/error-boundary";
 import { Toaster } from "@/components/ui/toaster";
+import WebsocketDebugMonitor from "@/components/websocket-debug-monitor";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ThemeProvider } from "@/components/theme-provider";
 import { MobileProvider } from "./context/MobileContext";
@@ -120,6 +121,7 @@ function App() {
           <ThemeProvider defaultTheme="light" storageKey="ticket-tracker-theme">
             <TooltipProvider>
               <Toaster />
+              {import.meta.env.DEV && <WebsocketDebugMonitor />}
               <AppLayout>
                 <Router />
               </AppLayout>

--- a/client/src/components/child-dashboard-header.tsx
+++ b/client/src/components/child-dashboard-header.tsx
@@ -33,8 +33,8 @@ export default function ChildDashboardHeader({ activeGoal }: ChildDashboardHeade
   return (
     <div className="mb-6 flex items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 shadow-sm">
       <div className="flex items-center space-x-4">
-        <ProgressRing percent={progress} size={64} strokeWidth={6} color="#fbbf24">
-          <Avatar className="h-12 w-12 border">
+        <ProgressRing percent={progress} radius={38} stroke={6}>
+          <Avatar className="h-14 w-14 border">
             <AvatarImage src={user.profile_image_url || undefined} alt={user.name} />
             <AvatarFallback className="bg-primary-600 text-white text-sm">
               {getInitials(user.name)}

--- a/client/src/components/layout/floating-exit-fab.tsx
+++ b/client/src/components/layout/floating-exit-fab.tsx
@@ -16,12 +16,13 @@ export default function FloatingExitFab() {
   };
 
   return (
-    <Button
+    <button
       onClick={handleClick}
-      aria-label="Return to Parent"
-      className="fixed bottom-4 left-4 z-50 rounded-full p-3 shadow bg-primary text-white hover:bg-primary/90"
+      aria-label="Return to parent"
+      className="fixed bottom-4 left-4 bg-amber-200 text-amber-900 rounded-full shadow-lg px-3 py-2 flex items-center gap-1 hover:bg-amber-300 focus-visible:outline transition-all"
     >
-      <ArrowLeft className="h-5 w-5" />
-    </Button>
+      <ArrowLeft className="h-4 w-4" />
+      <span className="hidden sm:inline">Parent</span>
+    </button>
   );
 }

--- a/client/src/components/progress-card.tsx
+++ b/client/src/components/progress-card.tsx
@@ -40,7 +40,6 @@ export default function ProgressCard({ goal, onRefresh }: ProgressCardProps) {
   const [, navigate] = useLocation();
   const { user, getChildUsers } = useAuthStore();
   const [hasShownConfetti, setHasShownConfetti] = useState(false);
-  const progressContainerRef = useRef<HTMLDivElement>(null);
   const { isMobile } = useMobile();
   
   // Track when we've passed milestone percentages
@@ -264,75 +263,6 @@ export default function ProgressCard({ goal, onRefresh }: ProgressCardProps) {
             </div>
           </div>
           
-          <div className="mt-3" ref={progressContainerRef}>
-            <div className="flex items-center justify-between text-sm mb-1">
-              <span className="text-gray-500 dark:text-gray-400">
-                Progress: {goal.tickets_saved} of {ticketsNeeded} tickets saved
-              </span>
-              <span className="font-medium text-primary-600 dark:text-primary-400">
-                {Math.floor(goal.progress)}%
-              </span>
-            </div>
-
-            {/* Enhanced progress bar with milestones */}
-            <div className="relative">
-              {/* Gradient progress bar */}
-              <div className="relative h-5 w-full rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
-                <div 
-                  className="h-full rounded-full bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 transition-all duration-1000 ease-out"
-                  style={{ width: `${Math.min(100, goal.progress)}%` }}
-                />
-                
-                {/* Milestone markers */}
-                {[25, 50, 75].map(milestone => (
-                  <div 
-                    key={`milestone-${milestone}`}
-                    className={`absolute top-0 bottom-0 flex items-center justify-center ${goal.progress >= milestone ? 'text-white' : 'text-gray-400 dark:text-gray-500'}`}
-                    style={{ left: `${milestone}%`, transform: 'translateX(-50%)' }}
-                  >
-                    {milestone === 25 && (
-                      <div className={`w-4 h-4 rounded-full ${goal.progress >= milestone ? 'bg-blue-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'} flex items-center justify-center`}>
-                        <Star className="w-2 h-2" />
-                      </div>
-                    )}
-                    {milestone === 50 && (
-                      <div className={`w-4 h-4 rounded-full ${goal.progress >= milestone ? 'bg-purple-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'} flex items-center justify-center`}>
-                        <Star className="w-2 h-2" />
-                      </div>
-                    )}
-                    {milestone === 75 && (
-                      <div className={`w-4 h-4 rounded-full ${goal.progress >= milestone ? 'bg-pink-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'} flex items-center justify-center`}>
-                        <Star className="w-2 h-2" />
-                      </div>
-                    )}
-                  </div>
-                ))}
-                
-                {/* Avatar indicator moving along the progress bar */}
-                <div 
-                  className="absolute top-0 transform -translate-y-1/2"
-                  style={{ 
-                    left: `${Math.min(98, Math.max(2, goal.progress))}%`, 
-                    transform: 'translateX(-50%)' 
-                  }}
-                >
-                  <Avatar className="w-6 h-6 border-2 border-white dark:border-gray-900 shadow-md">
-                    <AvatarImage src={profileImageUrl || undefined} alt={childName} />
-                    <AvatarFallback className="text-[10px] bg-primary text-white">
-                      {getInitials(childName)}
-                    </AvatarFallback>
-                  </Avatar>
-                </div>
-              </div>
-              
-              {/* 100% trophy marker */}
-              <div 
-                className={`absolute right-0 top-0 bottom-0 transform translate-x-1/2 flex items-center justify-center ${goal.progress >= 100 ? 'text-yellow-500 animate-bounce-slow' : 'text-gray-400'}`}
-              >
-                <Trophy className="w-6 h-6" />
-              </div>
-            </div>
-          </div>
         </div>
       </div>
       

--- a/client/src/components/swipeable-chore-card.tsx
+++ b/client/src/components/swipeable-chore-card.tsx
@@ -1,26 +1,24 @@
-import { useRef } from "react";
+import { useMemo } from "react";
+import { Swipeable } from "./swipeable";
+import confetti from "canvas-confetti";
 import ChoreCard, { type ChoreCardProps } from "./chore-card";
 
 export default function SwipeableChoreCard(props: ChoreCardProps) {
-  const startX = useRef<number | null>(null);
+  const disableSwipe = useMemo(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia("(pointer: fine)").matches;
+  }, []);
 
-  const onStart = (e: React.TouchEvent<HTMLDivElement>) => {
-    startX.current = e.touches[0].clientX;
-  };
-
-  const onEnd = (e: React.TouchEvent<HTMLDivElement>) => {
-    if (startX.current === null) return;
-    const diff = e.changedTouches[0].clientX - startX.current;
-    if (diff > 60) {
-      props.onComplete(props.chore.id).catch(() => {});
-      if (navigator.vibrate) navigator.vibrate(20);
-    }
-    startX.current = null;
+  const handleComplete = () => {
+    if (disableSwipe) return;
+    props.onComplete(props.chore.id).catch(() => {});
+    navigator.vibrate?.(24);
+    confetti({ particleCount: 60, spread: 60 });
   };
 
   return (
-    <div onTouchStart={onStart} onTouchEnd={onEnd}>
+    <Swipeable onSwipeEnd={handleComplete}>
       <ChoreCard {...props} />
-    </div>
+    </Swipeable>
   );
 }

--- a/client/src/components/swipeable.tsx
+++ b/client/src/components/swipeable.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+interface SwipeableProps extends React.HTMLAttributes<HTMLDivElement> {
+  onSwipeEnd?: () => void;
+}
+
+export const Swipeable = React.forwardRef<HTMLDivElement, SwipeableProps>(
+  ({ onSwipeEnd, children, ...props }, ref) => {
+    const startX = React.useRef<number | null>(null);
+
+    const handleStart = (e: React.TouchEvent<HTMLDivElement>) => {
+      startX.current = e.touches[0].clientX;
+    };
+
+    const handleEnd = (e: React.TouchEvent<HTMLDivElement>) => {
+      if (startX.current === null) return;
+      const diff = e.changedTouches[0].clientX - startX.current;
+      if (Math.abs(diff) > 40) {
+        onSwipeEnd?.();
+      }
+      startX.current = null;
+    };
+
+    return (
+      <div ref={ref} onTouchStart={handleStart} onTouchEnd={handleEnd} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+Swipeable.displayName = "Swipeable";

--- a/client/src/components/ui/progress-ring.tsx
+++ b/client/src/components/ui/progress-ring.tsx
@@ -1,58 +1,35 @@
-import { motion } from "framer-motion";
 import type { ReactNode } from "react";
 
 interface ProgressRingProps {
   percent: number;
-  size?: number;
-  strokeWidth?: number;
-  color?: string;
+  radius?: number;
+  stroke?: number;
   children?: ReactNode;
 }
 
-export function ProgressRing({ percent, size = 64, strokeWidth = 4, color = "#10b981", children }: ProgressRingProps) {
-  const radius = (size - strokeWidth) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const offset = circumference * (1 - Math.min(100, Math.max(0, percent)) / 100);
-
-  const ring = (
-    <svg width={size} height={size} className="block">
-      <circle
-        stroke="currentColor"
-        strokeWidth={strokeWidth}
-        className="text-gray-200 dark:text-gray-700"
-        fill="transparent"
-        r={radius}
-        cx={size / 2}
-        cy={size / 2}
-      />
-      <motion.circle
-        fill="transparent"
-        stroke={color}
-        strokeWidth={strokeWidth}
-        strokeLinecap="round"
-        r={radius}
-        cx={size / 2}
-        cy={size / 2}
-        strokeDasharray={circumference}
-        strokeDashoffset={offset}
-        initial={{ strokeDashoffset: circumference }}
-        animate={{ strokeDashoffset: offset }}
-        transition={{ ease: "easeOut", duration: 0.5 }}
-      />
-    </svg>
-  );
-
-  if (!children) {
-    return ring;
-  }
+export default function ProgressRing({ percent, radius = 38, stroke = 6, children }: ProgressRingProps) {
+  const r = radius - stroke / 2;
+  const circ = 2 * Math.PI * r;
+  const offset = circ - (percent / 100) * circ;
 
   return (
-    <div style={{ width: size, height: size }} className="relative">
-      {ring}
-      <div className="absolute inset-0 flex items-center justify-center">
-        {children}
-      </div>
-    </div>
+    <svg width={radius * 2} height={radius * 2} className="progress-ring">
+      <circle r={r} cx={radius} cy={radius} stroke="#E5E7EB" strokeWidth={stroke} fill="none" />
+      <circle
+        r={r}
+        cx={radius}
+        cy={radius}
+        stroke="#22C55E"
+        strokeWidth={stroke}
+        fill="none"
+        strokeDasharray={`${circ} ${circ}`}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        className="transition-[stroke-dashoffset] duration-700 ease-out"
+      />
+      <foreignObject x="0" y="0" width={radius * 2} height={radius * 2}>
+        <div className="flex items-center justify-center h-full">{children}</div>
+      </foreignObject>
+    </svg>
   );
 }
-export default ProgressRing;

--- a/client/src/components/websocket-debug-monitor.tsx
+++ b/client/src/components/websocket-debug-monitor.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { subscribeToChannel, createWebSocketConnection } from "@/lib/websocketClient";
+
+export default function WebsocketDebugMonitor() {
+  const [events, setEvents] = useState<string[]>([]);
+
+  useEffect(() => {
+    createWebSocketConnection();
+    const unsub = subscribeToChannel("", (e) => {
+      const msg = `[${new Date().toLocaleTimeString()}] ${e.event}`;
+      setEvents((prev) => [msg, ...prev].slice(0, 10));
+    });
+    return () => {
+      if (typeof unsub === "function") unsub();
+    };
+  }, []);
+
+  return (
+    <div className="fixed bottom-0 right-0 m-2 max-h-40 w-64 overflow-y-auto rounded bg-black/80 p-2 text-xs text-white z-50">
+      {events.map((e, i) => (
+        <div key={i}>{e}</div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/hooks/use-media-query.ts
+++ b/client/src/hooks/use-media-query.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const getMatches = () =>
+    typeof window !== "undefined" ? window.matchMedia(query).matches : false;
+
+  const [matches, setMatches] = useState(getMatches);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const listener = () => setMatches(media.matches);
+    listener();
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, [query]);
+
+  return matches;
+}

--- a/client/src/lib/websocketClient.ts
+++ b/client/src/lib/websocketClient.ts
@@ -68,12 +68,11 @@ export function createWebSocketConnection() {
       // Reset reconnect attempts on successful connection
       reconnectAttempts = 0;
       
-      // Only show success toast on first successful connection
-      if (!silentReconnect) {
+      // Show a quick success toast in development only
+      if (import.meta.env.DEV && !silentReconnect) {
         toast({
           title: "Realtime connection established",
-          description: "You'll receive real-time updates",
-          variant: "default"
+          duration: 1200,
         });
       }
       

--- a/client/src/pages/transactions.tsx
+++ b/client/src/pages/transactions.tsx
@@ -5,6 +5,7 @@ import { useStatsStore } from "@/store/stats-store";
 import { subscribeToChannel } from "@/lib/websocketClient";
 import TransactionsMobile from "@/components/transactions-mobile";
 import TransactionsTableDesktop from "@/components/transactions-table-desktop";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { 
   Card, 
   CardContent, 
@@ -36,6 +37,7 @@ export default function Transactions() {
   const { balance, updateBalance } = useStatsStore();
   const [userId, setUserId] = useState<string | undefined>(undefined);
   const isParent = user?.role === "parent";
+  const isDesktop = useMediaQuery('(min-width: 640px)');
   
   // Fetch users if current user is a parent
   const { data: users = [] } = useQuery<UserInfo[]>({
@@ -215,8 +217,11 @@ export default function Transactions() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <TransactionsMobile userId={userId} limit={25} />
-            <TransactionsTableDesktop userId={userId} limit={25} />
+            {isDesktop ? (
+              <TransactionsTableDesktop userId={userId} limit={25} />
+            ) : (
+              <TransactionsMobile userId={userId} limit={25} />
+            )}
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- show connection toast only in dev
- introduce simpler ProgressRing component and use in child header
- remove progress bar from progress card
- implement swipeable chore card with confetti feedback
- add floating exit FAB styling
- conditional transaction mobile/desktop views via media query
- provide WebsocketDebugMonitor gated to dev

## Testing
- `bun test`
- `npm run build`