### PR TITLE
Fix nav overlay and cleanup goal card

### DIFF
--- a/client/src/components/layout/mobile-nav.tsx
+++ b/client/src/components/layout/mobile-nav.tsx
@@ -17,14 +17,6 @@ import {
   SheetClose,
 } from "@/components/ui/sheet";
 
-// Navigation items with icons
-const navItems = [
-  { path: "/", label: "Home", icon: "ri-dashboard-line" },
-  { path: "/chores", label: "Chores", icon: "ri-list-check-2" },
-  { path: "/family-catalog", label: "Catalog", icon: "ri-store-2-line" }, // Renamed (shortened for mobile)
-  { path: "/transactions", label: "Tickets", icon: "ri-exchange-funds-line" },
-];
-
 // Parent-only navigation items
 const parentNavItems = [
   { path: "/bonus-management", label: "Bonus Mgmt", icon: "ri-award-line" },
@@ -41,14 +33,23 @@ interface UserInfo {
 export function MobileNav() {
   const [location, setLocation] = useLocation();
   const { theme, setTheme } = useTheme();
-  const { 
-    user, 
-    isViewingAsChild, 
+  const {
+    user,
+    isViewingAsChild,
     switchChildView,
     resetChildView,
     getChildUsers,
     familyUsers
   } = useAuthStore();
+  const viewingChildId = useAuthStore(state => state.viewingChildId);
+
+  const homeHref = viewingChildId ? '/parent-dashboard' : '/dashboard';
+  const navItems = [
+    { path: homeHref, label: 'Home', icon: 'ri-dashboard-line' },
+    { path: '/chores', label: 'Chores', icon: 'ri-list-check-2' },
+    { path: '/family-catalog', label: 'Catalog', icon: 'ri-store-2-line' },
+    { path: '/transactions', label: 'Tickets', icon: 'ri-exchange-funds-line' },
+  ];
   
   const [childUsers, setChildUsers] = useState<UserInfo[]>([]);
   
@@ -209,7 +210,7 @@ export function MobileNav() {
       </div>
       
       {/* Mobile bottom navigation */}
-      <div className="md:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 shadow-lg z-10">
+      <div className="md:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 shadow-lg z-50">
         <div className={`grid ${user?.role === 'parent' && !viewingAsChild ? 'grid-cols-5' : 'grid-cols-4'} h-16`}>
           {/* Regular navigation items */}
           {navItems.map(item => (

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -16,14 +16,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 
-// Navigation items with icons
-const navItems = [
-  { path: "/", label: "Dashboard", icon: "ri-dashboard-line" },
-  { path: "/chores", label: "Chores", icon: "ri-list-check-2" },
-  { path: "/family-catalog", label: "Family Catalog", icon: "ri-store-2-line" }, // Renamed
-  { path: "/transactions", label: "Transactions", icon: "ri-exchange-funds-line" },
-];
-
 // Parent-only navigation items
 const parentNavItems = [
   { path: "/bonus-management", label: "Bonus Management", icon: "ri-award-line" },
@@ -42,6 +34,15 @@ export function Sidebar() {
   const [location, setLocation] = useLocation();
   const { theme, setTheme } = useTheme();
   const { user, isViewingAsChild, switchChildView, resetChildView, getChildUsers, familyUsers } = useAuthStore();
+  const viewingChildId = useAuthStore(state => state.viewingChildId);
+
+  const homeHref = viewingChildId ? '/parent-dashboard' : '/dashboard';
+  const navItems = [
+    { path: homeHref, label: 'Dashboard', icon: 'ri-dashboard-line' },
+    { path: '/chores', label: 'Chores', icon: 'ri-list-check-2' },
+    { path: '/family-catalog', label: 'Family Catalog', icon: 'ri-store-2-line' },
+    { path: '/transactions', label: 'Transactions', icon: 'ri-exchange-funds-line' },
+  ];
   const [childUsers, setChildUsers] = useState<UserInfo[]>([]);
   
   useEffect(() => {
@@ -98,12 +99,12 @@ export function Sidebar() {
   return (
     <aside className="hidden md:flex flex-col w-64 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-sm">
       <div className="p-5 border-b border-gray-200 dark:border-gray-700">
-        <div className="flex items-center space-x-3">
+        <a href={homeHref} className="flex items-center space-x-3">
           <div className="bg-primary-600 p-2 rounded-lg">
             <i className="ri-ticket-2-line text-white text-xl"></i>
           </div>
           <h1 className="text-xl font-bold font-quicksand text-gray-800 dark:text-white">TicketTracker</h1>
-        </div>
+        </a>
       </div>
       
       {/* Quick access section - MOVED ABOVE NAVIGATION

--- a/client/src/components/progress-card.tsx
+++ b/client/src/components/progress-card.tsx
@@ -201,27 +201,7 @@ export default function ProgressCard({ goal, onRefresh }: ProgressCardProps) {
               </p>
             </div>
             
-            {/* Redesigned ticket display */}
-            <div className="mt-3 sm:mt-0">
-              <div className="flex flex-col items-end">
-                <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-amber-100 dark:bg-amber-900/40 border border-amber-200 dark:border-amber-800/50 mb-2">
-                  <div className="relative">
-                    <Ticket className="w-8 h-8 text-amber-600 dark:text-amber-400" strokeWidth={1.5} />
-                    <span className="absolute inset-0 flex items-center justify-center text-xs font-bold text-amber-800 dark:text-amber-300">
-                      {ticketsNeeded}
-                    </span>
-                  </div>
-                  <div className="flex flex-col">
-                    <span className="text-sm font-medium text-amber-800 dark:text-amber-300">
-                      {ticketsNeeded} tickets needed
-                    </span>
-                    <span className="text-xs text-amber-700 dark:text-amber-400">
-                      Value: ${(ticketsNeeded * ticketValueInCents / 100).toFixed(2)} USD
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
+            {/* info now shown in small text under progress bar */}
           </div>
 
           {/* Enhanced ticket value display with more visual elements */}
@@ -262,8 +242,11 @@ export default function ProgressCard({ goal, onRefresh }: ProgressCardProps) {
               </div>
             </div>
           </div>
-          
+
         </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {ticketsRemaining} tickets to go
+        </p>
       </div>
       
       <div className="p-4 bg-gray-50 dark:bg-gray-800/50 flex items-center justify-between flex-wrap gap-2">

--- a/client/src/components/ui/toast.tsx
+++ b/client/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-40 flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- drop toast overlay z-index so nav covers it
- raise mobile nav `z` layer
- remove bulky goal tile and show tiny remaining text
- compute dynamic home links in mobile nav and sidebar

## Testing
- `npm test`